### PR TITLE
chore: bump node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:14-alpine
+FROM node:lts-alpine3.16
 
 # Set the working directory to /app
 WORKDIR /app


### PR DESCRIPTION
```bash
docker build -t nestjs-boilerplate .
```
```bash
docker run -p 3000:3000 -v .:/app nestjs-boilerplate
```